### PR TITLE
Fix DeprecationWarning time.clock python 3.8

### DIFF
--- a/nptdms/utils.py
+++ b/nptdms/utils.py
@@ -7,9 +7,9 @@ class Timer(object):
         self._description = description
 
     def __enter__(self):
-        self._start_time = time.clock()
+        self._start_time = time.perf_counter()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        elapsed_time = (time.clock() - self._start_time) * 1.0e3
+        elapsed_time = (time.perf_counter() - self._start_time) * 1.0e3
         self._log.info("{0}: Took {1} ms".format(
             self._description, elapsed_time))


### PR DESCRIPTION
While running pytest for .tdms files in Python 3.7 I got a Deprecation Warning that time.clock() as used in the utils.py file of the nptdms package will be no longer available in Python 3.8. I propose replacing time.clock() by time.perf_counter(), which makes it compatible with Python 3.8. 

For deprecation of time.clock(), see https://docs.python.org/3/library/time.html#time.clock 